### PR TITLE
Update sync-repo.sh

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,17 +1,15 @@
 # This bash script uses git to sync changes between a local and remote GitHub repository on branch 'main'.
 # It assumes that the remote repository is already set up and that the local repository is already cloned.
 
-# Steps: pull changes from remote repository, stage all changes, commit changes with message 'Updated', push changes to remote repository on branch 'main'.
-
 # Pull changes from remote repository
-git pull origin main
+git pull 
 
 # Stage all changes
 git stage .
 
 # Commit changes with message 'Synced changes'
-git commit -m "Synced changes"
+git commit -m "Updated"
 
 # Push changes to remote repository on branch 'main'
-git push origin main
+git push 
 


### PR DESCRIPTION
This pull request includes a small change to the `sync-repo.sh` script. The change simplifies the git commands by removing the explicit branch name `main` from the `pull` and `push` commands.